### PR TITLE
Handle empty matches differently (and some optimizations)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 module.exports = function (regexp, string) {
   var match, matches = [];
 
@@ -10,9 +9,10 @@ module.exports = function (regexp, string) {
   }
 
   while (match = regexp.exec(string)) {
-    matches.push(match);
-    if (match[0] == '') {
-      break;
+    if (match[0] === '') {
+      regexp.lastIndex++;
+    } else {
+      matches.push(match);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 module.exports = function (regexp, string) {
+  if (!string) return [];
+
   if (!regexp.global) {
     var match = regexp.exec(string);
     return match ? [match] : [];

--- a/index.js
+++ b/index.js
@@ -1,13 +1,12 @@
 'use strict';
 
 module.exports = function (regexp, string) {
-  var match, matches = [];
-
   if (!regexp.global) {
-    match = regexp.exec(string);
+    var match = regexp.exec(string);
     return match ? [match] : [];
   }
 
+  var matches = [];
   while (match = regexp.exec(string)) {
     if (match[0] === '') {
       regexp.lastIndex++;

--- a/index.js
+++ b/index.js
@@ -3,12 +3,14 @@
 module.exports = function (regexp, string) {
   if (!string) return [];
 
+  var match = regexp.exec(string);
+  if (!match) return [];
+
   if (!regexp.global) {
-    var match = regexp.exec(string);
-    return match ? [match] : [];
+    return [match];
   }
 
-  var matches = [];
+  var matches = [match];
   while (match = regexp.exec(string)) {
     if (match[0] === '') {
       regexp.lastIndex++;

--- a/test/test.js
+++ b/test/test.js
@@ -44,16 +44,10 @@ describe('for a global regexp', function () {
     execAll(/.*/g, input).should.eql([assign(['12345'], {
       index: 0,
       input: input
-    }), assign([''], {
-      index: 5,
-      input: input
     })]);
 
     execAll(/1?/g, input).should.eql([assign(['1'], {
       index: 0,
-      input: input
-    }), assign([''], {
-      index: 1,
       input: input
     })]);
   });


### PR DESCRIPTION
Changes I've made:

- Handle empty matches differently
  - Exclude empty matches from the results
  - Increment the position instead of breaking out of the loop
&nbsp;
- Optimize non-global `regexp`
&nbsp;
- Optimize falsy `string`
&nbsp;
- Optimize first match
&nbsp;